### PR TITLE
fix: User report bug fixes

### DIFF
--- a/frontend/e2e/edit-card.spec.ts
+++ b/frontend/e2e/edit-card.spec.ts
@@ -1,0 +1,86 @@
+import { test, expect } from "@playwright/test";
+
+test.describe("Edit Card", () => {
+  test("can edit a published card via edit button", async ({ page }) => {
+    // Create a room
+    await page.goto("/");
+    await page.getByRole("button", { name: "Create Room" }).first().click();
+    await page.getByLabel("Room Name").fill("Edit Card Test");
+    await page
+      .locator("form")
+      .getByRole("button", { name: "Create Room" })
+      .click();
+    await expect(page).toHaveURL(/\/room\//);
+
+    // Add a column
+    await page.getByLabel("New column name").fill("Ideas");
+    await page.getByRole("button", { name: "Add Column" }).click();
+
+    // Go to publish mode
+    await page.getByRole("button", { name: "Start Publishing" }).click();
+
+    // Add and publish a card
+    const draftInput = page
+      .getByRole("textbox", { name: "Add a new card..." })
+      .first();
+    await draftInput.fill("Original text");
+    await page.getByRole("button", { name: "Add Draft" }).first().click();
+    await page.getByRole("button", { name: /Publish All/ }).click();
+
+    // Verify original content
+    await expect(page.getByText("Original text")).toBeVisible();
+
+    // Click edit button
+    await page.getByRole("button", { name: "Edit this card" }).click();
+
+    // Verify textarea appears with original content
+    const textarea = page.getByRole("textbox", { name: "Edit card content" });
+    await expect(textarea).toBeVisible();
+    await expect(textarea).toHaveValue("Original text");
+
+    // Edit the content
+    await textarea.clear();
+    await textarea.fill("Updated text");
+    await textarea.press("Enter");
+
+    // Verify card shows updated content
+    await expect(page.getByText("Updated text")).toBeVisible();
+    await expect(page.getByText("Original text")).not.toBeVisible();
+  });
+
+  test("can cancel edit with Escape", async ({ page }) => {
+    // Create a room with a published card
+    await page.goto("/");
+    await page.getByRole("button", { name: "Create Room" }).first().click();
+    await page.getByLabel("Room Name").fill("Cancel Edit Test");
+    await page
+      .locator("form")
+      .getByRole("button", { name: "Create Room" })
+      .click();
+    await expect(page).toHaveURL(/\/room\//);
+
+    await page.getByLabel("New column name").fill("Column");
+    await page.getByRole("button", { name: "Add Column" }).click();
+    await page.getByRole("button", { name: "Start Publishing" }).click();
+
+    const draftInput = page
+      .getByRole("textbox", { name: "Add a new card..." })
+      .first();
+    await draftInput.fill("Keep this text");
+    await page.getByRole("button", { name: "Add Draft" }).first().click();
+    await page.getByRole("button", { name: /Publish All/ }).click();
+
+    // Start editing
+    await page.getByRole("button", { name: "Edit this card" }).click();
+    const textarea = page.getByRole("textbox", { name: "Edit card content" });
+    await textarea.clear();
+    await textarea.fill("Changed text");
+
+    // Cancel with Escape
+    await textarea.press("Escape");
+
+    // Original text should remain
+    await expect(page.getByText("Keep this text")).toBeVisible();
+    await expect(page.getByText("Changed text")).not.toBeVisible();
+  });
+});

--- a/frontend/e2e/long-text.spec.ts
+++ b/frontend/e2e/long-text.spec.ts
@@ -1,0 +1,55 @@
+import { test, expect } from "@playwright/test";
+
+test.describe("Long Text", () => {
+  test("long unbroken text wraps in focus mode discussion modal", async ({
+    page,
+  }) => {
+    // Create a room
+    await page.goto("/");
+    await page.getByRole("button", { name: "Create Room" }).first().click();
+    await page.getByLabel("Room Name").fill("Long Text Test");
+    await page
+      .locator("form")
+      .getByRole("button", { name: "Create Room" })
+      .click();
+    await expect(page).toHaveURL(/\/room\//);
+
+    // Add a column
+    await page.getByLabel("New column name").fill("Ideas");
+    await page.getByRole("button", { name: "Add Column" }).click();
+
+    // Go to publish mode
+    await page.getByRole("button", { name: "Start Publishing" }).click();
+
+    // Add a card with very long unbroken text
+    const longText =
+      "ThisIsAnExtremelyLongWordWithoutAnySpacesThatShouldWrapProperlyInAllModesAndNotOverflowTheContainerBoundaries";
+    const draftInput = page
+      .getByRole("textbox", { name: "Add a new card..." })
+      .first();
+    await draftInput.fill(longText);
+    await page.getByRole("button", { name: "Add Draft" }).first().click();
+    await page.getByRole("button", { name: /Publish All/ }).click();
+
+    // Advance through modes to focus
+    await page.getByRole("button", { name: "Start Grouping" }).click();
+    await page.getByRole("button", { name: "Start Voting" }).click();
+    await page.getByRole("button", { name: "Start Discussion" }).click();
+
+    // Open the discussion modal
+    await page.getByRole("button", { name: /Discuss card/ }).click();
+    const dialog = page.getByRole("dialog");
+    await expect(dialog).toBeVisible();
+
+    // The card text should be fully visible (wrapped, not overflowing)
+    const cardText = dialog.locator("p").first();
+    await expect(cardText).toContainText(longText);
+
+    // The text element should not be wider than the modal
+    const modalBox = await dialog.boundingBox();
+    const textBox = await cardText.boundingBox();
+    expect(modalBox).toBeTruthy();
+    expect(textBox).toBeTruthy();
+    expect(textBox!.width).toBeLessThanOrEqual(modalBox!.width);
+  });
+});

--- a/frontend/e2e/name-change.spec.ts
+++ b/frontend/e2e/name-change.spec.ts
@@ -1,0 +1,67 @@
+import { test, expect } from "@playwright/test";
+
+test.describe("Name Change", () => {
+  test("can rename user via participants modal", async ({ page }) => {
+    // Create a room
+    await page.goto("/");
+    await page.getByRole("button", { name: "Create Room" }).first().click();
+    await page.getByLabel("Room Name").fill("Rename Test");
+    await page
+      .locator("form")
+      .getByRole("button", { name: "Create Room" })
+      .click();
+    await expect(page).toHaveURL(/\/room\//);
+
+    // Open participants modal
+    await page.getByRole("button", { name: "View participants" }).click();
+    await expect(
+      page.getByRole("dialog", { name: "Participants" })
+    ).toBeVisible();
+
+    // Note the original name
+    const originalName = await page.locator(".participant-name").textContent();
+    expect(originalName).toBeTruthy();
+
+    // Click edit button and change name
+    await page.getByRole("button", { name: "Edit your name" }).click();
+    const input = page.getByRole("textbox", { name: "Edit your name" });
+    await input.clear();
+    await input.fill("Alice");
+    await input.press("Enter");
+
+    // Verify name changed in the modal
+    await expect(page.locator(".participant-name")).toHaveText("Alice");
+  });
+
+  test("renamed name persists after page refresh", async ({ page }) => {
+    // Create a room
+    await page.goto("/");
+    await page.getByRole("button", { name: "Create Room" }).first().click();
+    await page.getByLabel("Room Name").fill("Persist Name Test");
+    await page
+      .locator("form")
+      .getByRole("button", { name: "Create Room" })
+      .click();
+    await expect(page).toHaveURL(/\/room\//);
+    const roomUrl = page.url();
+
+    // Rename user
+    await page.getByRole("button", { name: "View participants" }).click();
+    await page.getByRole("button", { name: "Edit your name" }).click();
+    const input = page.getByRole("textbox", { name: "Edit your name" });
+    await input.clear();
+    await input.fill("Bob");
+    await input.press("Enter");
+    await expect(page.locator(".participant-name")).toHaveText("Bob");
+
+    // Close modal
+    await page.getByRole("button", { name: "Close" }).click();
+
+    // Refresh the page
+    await page.goto(roomUrl);
+
+    // Open participants and verify name persisted
+    await page.getByRole("button", { name: "View participants" }).click();
+    await expect(page.locator(".participant-name")).toHaveText("Bob");
+  });
+});

--- a/frontend/e2e/participants.spec.ts
+++ b/frontend/e2e/participants.spec.ts
@@ -1,0 +1,83 @@
+import { test, expect } from "@playwright/test";
+
+test.describe("Participants", () => {
+  test("owner badge shows for room creator in participants modal", async ({
+    page,
+  }) => {
+    // Create a room
+    await page.goto("/");
+    await page.getByRole("button", { name: "Create Room" }).first().click();
+    await page.getByLabel("Room Name").fill("Owner Badge Test");
+    await page
+      .locator("form")
+      .getByRole("button", { name: "Create Room" })
+      .click();
+    await expect(page).toHaveURL(/\/room\//);
+
+    // Open participants modal
+    await page.getByRole("button", { name: "View participants" }).click();
+
+    // Verify the modal shows
+    const dialog = page.getByRole("dialog", { name: /Participants/ });
+    await expect(dialog).toBeVisible();
+
+    // Verify owner badge is shown
+    await expect(dialog.getByText("Owner")).toBeVisible();
+
+    // Verify (You) badge is shown
+    await expect(dialog.getByText("(You)")).toBeVisible();
+  });
+
+  test("participant does not have owner badge", async ({ browser }) => {
+    // Create a room as owner
+    const ownerContext = await browser.newContext();
+    const ownerPage = await ownerContext.newPage();
+    await ownerPage.goto("/");
+    await ownerPage
+      .getByRole("button", { name: "Create Room" })
+      .first()
+      .click();
+    await ownerPage.getByLabel("Room Name").fill("Participant Test");
+    await ownerPage
+      .locator("form")
+      .getByRole("button", { name: "Create Room" })
+      .click();
+    await expect(ownerPage).toHaveURL(/\/room\//);
+
+    // Get the room URL
+    const roomUrl = ownerPage.url();
+
+    // Join as participant in a separate browser context (no owner key)
+    const participantContext = await browser.newContext();
+    const participantPage = await participantContext.newPage();
+    await participantPage.goto(roomUrl);
+
+    // Wait for connection
+    await expect(
+      participantPage.getByRole("button", { name: "View participants" })
+    ).toContainText("2 participants");
+
+    // Open participants modal as participant
+    await participantPage
+      .getByRole("button", { name: "View participants" })
+      .click();
+    const dialog = participantPage.getByRole("dialog", {
+      name: /Participants/,
+    });
+    await expect(dialog).toBeVisible();
+
+    // Verify participant sees Owner badge on the owner user
+    await expect(dialog.getByText("Owner")).toBeVisible();
+
+    // Verify participant sees (You) badge on themselves
+    await expect(dialog.getByText("(You)")).toBeVisible();
+
+    // The participant's header should show "Participant" not "Owner"
+    await expect(
+      participantPage.locator(".role-badge.participant")
+    ).toBeVisible();
+
+    await ownerContext.close();
+    await participantContext.close();
+  });
+});

--- a/frontend/e2e/scrollbar.spec.ts
+++ b/frontend/e2e/scrollbar.spec.ts
@@ -1,0 +1,55 @@
+import { test, expect } from "@playwright/test";
+
+test.describe("Column Scrollbar", () => {
+  test("column cards area is scrollable when cards overflow", async ({
+    page,
+  }) => {
+    // Use a smaller viewport to ensure cards overflow
+    await page.setViewportSize({ width: 800, height: 600 });
+    // Create a room
+    await page.goto("/");
+    await page.getByRole("button", { name: "Create Room" }).first().click();
+    await page.getByLabel("Room Name").fill("Scroll Test");
+    await page
+      .locator("form")
+      .getByRole("button", { name: "Create Room" })
+      .click();
+    await expect(page).toHaveURL(/\/room\//);
+
+    // Add a column
+    await page.getByLabel("New column name").fill("Test Column");
+    await page.getByRole("button", { name: "Add Column" }).click();
+
+    // Go to publish mode
+    await page.getByRole("button", { name: "Start Publishing" }).click();
+
+    // Add many cards to trigger overflow
+    const draftInput = page
+      .getByRole("textbox", { name: "Add a new card..." })
+      .first();
+    const addDraftBtn = page.getByRole("button", { name: "Add Draft" }).first();
+
+    for (let i = 0; i < 8; i++) {
+      await draftInput.fill(`Card number ${i + 1} with some content`);
+      await addDraftBtn.click();
+    }
+
+    // Publish all
+    await page.getByRole("button", { name: /Publish All/ }).click();
+
+    // Verify the column-cards area is scrollable
+    const isScrollable = await page.evaluate(() => {
+      const cards = document.querySelector(".column-cards");
+      if (!cards) return false;
+      return cards.scrollHeight > cards.clientHeight;
+    });
+    expect(isScrollable).toBe(true);
+
+    // Verify overflow-y is auto
+    const overflowY = await page.evaluate(() => {
+      const cards = document.querySelector(".column-cards");
+      return cards ? getComputedStyle(cards).overflowY : "";
+    });
+    expect(overflowY).toBe("auto");
+  });
+});

--- a/frontend/e2e/scrollbar.spec.ts
+++ b/frontend/e2e/scrollbar.spec.ts
@@ -4,8 +4,8 @@ test.describe("Column Scrollbar", () => {
   test("column cards area is scrollable when cards overflow", async ({
     page,
   }) => {
-    // Use a smaller viewport to ensure cards overflow
-    await page.setViewportSize({ width: 800, height: 600 });
+    // Use a very small viewport to ensure cards overflow
+    await page.setViewportSize({ width: 800, height: 400 });
     // Create a room
     await page.goto("/");
     await page.getByRole("button", { name: "Create Room" }).first().click();
@@ -29,13 +29,22 @@ test.describe("Column Scrollbar", () => {
       .first();
     const addDraftBtn = page.getByRole("button", { name: "Add Draft" }).first();
 
-    for (let i = 0; i < 8; i++) {
-      await draftInput.fill(`Card number ${i + 1} with some content`);
+    for (let i = 0; i < 15; i++) {
+      await draftInput.fill(
+        `Card number ${i + 1} with enough content to take up space`
+      );
       await addDraftBtn.click();
     }
 
     // Publish all
     await page.getByRole("button", { name: /Publish All/ }).click();
+
+    // Verify overflow-y is set to auto (the CSS fix)
+    const overflowY = await page.evaluate(() => {
+      const cards = document.querySelector(".column-cards");
+      return cards ? getComputedStyle(cards).overflowY : "";
+    });
+    expect(overflowY).toBe("auto");
 
     // Verify the column-cards area is scrollable
     const isScrollable = await page.evaluate(() => {
@@ -44,12 +53,5 @@ test.describe("Column Scrollbar", () => {
       return cards.scrollHeight > cards.clientHeight;
     });
     expect(isScrollable).toBe(true);
-
-    // Verify overflow-y is auto
-    const overflowY = await page.evaluate(() => {
-      const cards = document.querySelector(".column-cards");
-      return cards ? getComputedStyle(cards).overflowY : "";
-    });
-    expect(overflowY).toBe("auto");
   });
 });

--- a/frontend/eslint.config.js
+++ b/frontend/eslint.config.js
@@ -19,5 +19,8 @@ export default defineConfig([
       ecmaVersion: 2020,
       globals: globals.browser,
     },
+    rules: {
+      'react-refresh/only-export-components': ['warn', { allowExportNames: ['useRoom', 'useUser'] }],
+    },
   },
 ])

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -1201,6 +1201,54 @@
   color: #888;
 }
 
+.card-content.editable {
+  cursor: pointer;
+}
+
+.card-content.editable:hover {
+  background: rgba(102, 126, 234, 0.05);
+  border-radius: 4px;
+  margin: -2px;
+  padding: 2px;
+}
+
+.card-edit-textarea {
+  width: 100%;
+  padding: 0.5rem;
+  border: 1px solid #667eea;
+  border-radius: 6px;
+  background: rgba(255, 255, 255, 0.05);
+  color: inherit;
+  font-size: 0.875rem;
+  font-family: inherit;
+  line-height: 1.5;
+  resize: vertical;
+  min-height: 60px;
+  box-sizing: border-box;
+  margin-bottom: 0.5rem;
+}
+
+.card-edit-textarea:focus {
+  outline: none;
+  border-color: #667eea;
+  box-shadow: 0 0 0 2px rgba(102, 126, 234, 0.2);
+}
+
+.card-edit-btn {
+  padding: 0.25rem 0.5rem;
+  border: none;
+  background: transparent;
+  color: #666;
+  cursor: pointer;
+  border-radius: 4px;
+  transition: color 0.2s, background 0.2s;
+}
+
+.card-edit-btn:hover {
+  color: #667eea;
+  background: rgba(102, 126, 234, 0.1);
+}
+
 .card-delete-btn {
   margin-left: auto;
   padding: 0.25rem 0.5rem;

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -1093,6 +1093,7 @@
   padding: 1rem;
   background: rgba(255, 255, 255, 0.05);
   border-bottom: 1px solid rgba(255, 255, 255, 0.1);
+  flex-shrink: 0;
 }
 
 .column-title-container {
@@ -1230,11 +1231,10 @@
   padding: 1rem;
   background: rgba(0, 0, 0, 0.1);
   max-height: 200px;
-  min-height: 120px;
   display: flex;
   flex-direction: column;
   overflow: hidden;
-  flex-shrink: 0;
+  flex-shrink: 1;
 }
 
 .draft-area-header {

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -1767,6 +1767,7 @@
   width: 100%;
   max-height: 80vh;
   overflow-y: auto;
+  overflow-x: hidden;
   border: 1px solid rgba(255, 255, 255, 0.1);
 }
 
@@ -1811,6 +1812,8 @@
   font-size: 1.25rem;
   line-height: 1.5;
   margin: 0 0 1rem 0;
+  word-break: break-word;
+  overflow-wrap: break-word;
 }
 
 .focus-modal-meta {
@@ -1861,6 +1864,8 @@
   font-size: 1rem;
   line-height: 1.4;
   margin: 0 0 0.5rem 0;
+  word-break: break-word;
+  overflow-wrap: break-word;
 }
 
 .focus-modal-group-card .focus-modal-card-author {

--- a/frontend/src/components/Card.tsx
+++ b/frontend/src/components/Card.tsx
@@ -1,3 +1,4 @@
+import { useState, useRef, useEffect } from "react";
 import type { Card as CardType } from "../types";
 import { useUser } from "../contexts/UserContext";
 import { useRoom } from "../contexts/RoomContext";
@@ -14,9 +15,22 @@ export function Card({
   showDelete = true,
 }: CardProps) {
   const { user } = useUser();
-  const { deleteCard } = useRoom();
+  const { deleteCard, editCard } = useRoom();
+  const [editing, setEditing] = useState(false);
+  const [editContent, setEditContent] = useState(card.content);
+  const textareaRef = useRef<HTMLTextAreaElement>(null);
 
   const isOwnCard = user?.id === card.authorId;
+
+  useEffect(() => {
+    if (editing && textareaRef.current) {
+      textareaRef.current.focus();
+      textareaRef.current.setSelectionRange(
+        textareaRef.current.value.length,
+        textareaRef.current.value.length
+      );
+    }
+  }, [editing]);
 
   const handleDelete = () => {
     if (isOwnCard) {
@@ -24,14 +38,72 @@ export function Card({
     }
   };
 
+  const handleStartEdit = () => {
+    if (isOwnCard) {
+      setEditContent(card.content);
+      setEditing(true);
+    }
+  };
+
+  const handleSaveEdit = () => {
+    const trimmed = editContent.trim();
+    if (trimmed && trimmed !== card.content) {
+      editCard(card.id, trimmed);
+    }
+    setEditing(false);
+  };
+
+  const handleCancelEdit = () => {
+    setEditContent(card.content);
+    setEditing(false);
+  };
+
+  const handleKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === "Escape") {
+      handleCancelEdit();
+    } else if (e.key === "Enter" && !e.shiftKey) {
+      e.preventDefault();
+      handleSaveEdit();
+    }
+  };
+
   return (
     <div className={`card-item ${isOwnCard ? "own-card" : ""}`}>
-      <p className="card-content">{card.content}</p>
+      {editing ? (
+        <textarea
+          ref={textareaRef}
+          className="card-edit-textarea"
+          value={editContent}
+          onChange={(e) => setEditContent(e.target.value)}
+          onKeyDown={handleKeyDown}
+          onBlur={handleSaveEdit}
+          maxLength={1000}
+          aria-label="Edit card content"
+        />
+      ) : (
+        <p
+          className={`card-content${isOwnCard ? " editable" : ""}`}
+          onClick={isOwnCard ? handleStartEdit : undefined}
+          title={isOwnCard ? "Click to edit" : undefined}
+        >
+          {card.content}
+        </p>
+      )}
       <div className="card-footer">
         {showAuthor && (
           <span className="card-author" title={card.authorName}>
             {isOwnCard ? "You" : card.authorName}
           </span>
+        )}
+        {isOwnCard && !editing && (
+          <button
+            className="card-edit-btn"
+            onClick={handleStartEdit}
+            title="Edit card"
+            aria-label="Edit this card"
+          >
+            ✎
+          </button>
         )}
         {showDelete && isOwnCard && (
           <button

--- a/frontend/src/contexts/RoomContext.tsx
+++ b/frontend/src/contexts/RoomContext.tsx
@@ -3,7 +3,6 @@ import {
   useContext,
   useState,
   useCallback,
-  useEffect,
   useRef,
   type ReactNode,
 } from "react";
@@ -81,9 +80,7 @@ export function RoomProvider({ roomId, children }: RoomProviderProps) {
 
   // Load stored user ID and owner key for this room
   const [storedUserId] = useState(() => loadUserId(roomId));
-  useEffect(() => {
-    loadOwnerKey(roomId);
-  }, [roomId, loadOwnerKey]);
+  const [storedOwnerKey] = useState(() => loadOwnerKey(roomId));
 
   const handleMessage = useCallback(
     (message: ServerMessage) => {
@@ -352,6 +349,7 @@ export function RoomProvider({ roomId, children }: RoomProviderProps) {
     onDisconnect: handleDisconnect,
     onError: handleError,
     userId: storedUserId ?? undefined,
+    ownerKey: storedOwnerKey ?? undefined,
   });
 
   // Helper to send messages

--- a/frontend/src/contexts/RoomContext.tsx
+++ b/frontend/src/contexts/RoomContext.tsx
@@ -35,6 +35,7 @@ interface RoomContextValue {
   // Participant actions
   publishCard: (columnId: string, content: string) => void;
   deleteCard: (cardId: string) => void;
+  editCard: (cardId: string, content: string) => void;
   groupCards: (cardIds: string[]) => void;
   ungroupCard: (cardId: string) => void;
   toggleVote: (targetId: string, targetType: "card" | "group") => void;
@@ -152,6 +153,16 @@ export function RoomProvider({ roomId, children }: RoomProviderProps) {
 
         case "card_deleted":
           setCards((prev) => prev.filter((c) => c.id !== message.cardId));
+          break;
+
+        case "card_edited":
+          setCards((prev) =>
+            prev.map((card) =>
+              card.id === message.cardId
+                ? { ...card, content: message.content }
+                : card
+            )
+          );
           break;
 
         case "cards_grouped":
@@ -366,6 +377,13 @@ export function RoomProvider({ roomId, children }: RoomProviderProps) {
     [sendMessage]
   );
 
+  const editCard = useCallback(
+    (cardId: string, content: string) => {
+      sendMessage({ type: "edit_card", cardId, content });
+    },
+    [sendMessage]
+  );
+
   const groupCardsAction = useCallback(
     (cardIds: string[]) => {
       sendMessage({ type: "group_cards", cardIds });
@@ -509,6 +527,7 @@ export function RoomProvider({ roomId, children }: RoomProviderProps) {
     error,
     publishCard,
     deleteCard,
+    editCard,
     groupCards: groupCardsAction,
     ungroupCard,
     toggleVote: toggleVoteAction,

--- a/frontend/src/contexts/RoomContext.tsx
+++ b/frontend/src/contexts/RoomContext.tsx
@@ -328,7 +328,7 @@ export function RoomProvider({ roomId, children }: RoomProviderProps) {
           break;
       }
     },
-    [setUser]
+    [groups, roomId, saveUserId, setUser]
   );
 
   const handleConnect = useCallback(() => {

--- a/frontend/src/contexts/UserContext.tsx
+++ b/frontend/src/contexts/UserContext.tsx
@@ -3,7 +3,6 @@ import {
   useContext,
   useState,
   useCallback,
-  useEffect,
   type ReactNode,
   type SetStateAction,
 } from "react";
@@ -122,18 +121,6 @@ export function UserProvider({ children }: UserProviderProps) {
   const clearDraftCards = useCallback(() => {
     setDraftCards([]);
   }, []);
-
-  // Update user.isOwner when ownerKey changes
-  useEffect(() => {
-    setUser((currentUser) => {
-      if (!currentUser) return null;
-      const shouldBeOwner = !!ownerKey;
-      if (currentUser.isOwner !== shouldBeOwner) {
-        return { ...currentUser, isOwner: shouldBeOwner };
-      }
-      return currentUser;
-    });
-  }, [ownerKey]);
 
   const value: UserContextValue = {
     user,

--- a/frontend/src/contexts/UserContext.tsx
+++ b/frontend/src/contexts/UserContext.tsx
@@ -5,6 +5,7 @@ import {
   useCallback,
   useEffect,
   type ReactNode,
+  type SetStateAction,
 } from "react";
 import type { User, DraftCard } from "../types";
 import { generateId } from "../utils";
@@ -16,7 +17,7 @@ interface UserContextValue {
   user: User | null;
   ownerKey: string | null;
   draftCards: DraftCard[];
-  setUser: (user: User | null) => void;
+  setUser: (user: SetStateAction<User | null>) => void;
   setOwnerKey: (key: string | null, roomId?: string) => void;
   loadOwnerKey: (roomId: string) => string | null;
   saveUserId: (roomId: string, userId: string) => void;

--- a/frontend/src/hooks/useWebSocket.ts
+++ b/frontend/src/hooks/useWebSocket.ts
@@ -8,6 +8,7 @@ interface UseWebSocketOptions {
   onDisconnect?: () => void;
   onError?: (error: Event) => void;
   userId?: string;
+  ownerKey?: string;
 }
 
 interface UseWebSocketReturn {
@@ -25,7 +26,8 @@ export function useWebSocket(
   roomId: string | null,
   options: UseWebSocketOptions = {}
 ): UseWebSocketReturn {
-  const { onMessage, onConnect, onDisconnect, onError, userId } = options;
+  const { onMessage, onConnect, onDisconnect, onError, userId, ownerKey } =
+    options;
 
   const [isConnected, setIsConnected] = useState(false);
   const [lastMessage, setLastMessage] = useState<ServerMessage | null>(null);
@@ -66,9 +68,11 @@ export function useWebSocket(
     }
   }, []);
 
-  // Store userId in ref to use during reconnection
+  // Store userId and ownerKey in refs to use during reconnection
   const userIdRef = useRef(userId);
   userIdRef.current = userId;
+  const ownerKeyRef = useRef(ownerKey);
+  ownerKeyRef.current = ownerKey;
 
   const connect = useCallback(
     (targetRoomId: string) => {
@@ -86,7 +90,11 @@ export function useWebSocket(
         return;
       }
 
-      const url = getWebSocketUrl(targetRoomId, userIdRef.current);
+      const url = getWebSocketUrl(
+        targetRoomId,
+        userIdRef.current,
+        ownerKeyRef.current
+      );
       const ws = new WebSocket(url);
 
       ws.onopen = () => {

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -34,12 +34,17 @@ export async function checkRoom(roomId: string): Promise<CheckRoomResponse> {
   return response.json();
 }
 
-export function getWebSocketUrl(roomId: string, userId?: string): string {
+export function getWebSocketUrl(
+  roomId: string,
+  userId?: string,
+  ownerKey?: string
+): string {
   const wsProtocol = API_URL.startsWith("https") ? "wss" : "ws";
   const wsHost = API_URL.replace(/^https?:\/\//, "");
   const baseUrl = `${wsProtocol}://${wsHost}/api/rooms/${roomId}/ws`;
-  if (userId) {
-    return `${baseUrl}?userId=${encodeURIComponent(userId)}`;
-  }
-  return baseUrl;
+  const params = new URLSearchParams();
+  if (userId) params.set("userId", userId);
+  if (ownerKey) params.set("ownerKey", ownerKey);
+  const qs = params.toString();
+  return qs ? `${baseUrl}?${qs}` : baseUrl;
 }

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -69,6 +69,7 @@ export type ClientMessage =
   | { type: "join"; userName?: string; userId?: string }
   | { type: "publish_card"; columnId: string; content: string }
   | { type: "delete_card"; cardId: string }
+  | { type: "edit_card"; cardId: string; content: string }
   | { type: "group_cards"; cardIds: string[] }
   | { type: "ungroup_card"; cardId: string }
   | { type: "toggle_vote"; targetId: string; targetType: "card" | "group" }
@@ -106,6 +107,7 @@ export type ServerMessage =
   | { type: "user_renamed"; userId: string; newName: string }
   | { type: "card_published"; card: Card }
   | { type: "card_deleted"; cardId: string }
+  | { type: "card_edited"; cardId: string; content: string }
   | { type: "cards_grouped"; group: CardGroup }
   | { type: "card_ungrouped"; cardId: string }
   | {

--- a/worker/src/room.ts
+++ b/worker/src/room.ts
@@ -137,11 +137,14 @@ export class RoomDO {
       const pair = new WebSocketPair();
       const [client, server] = Object.values(pair);
 
-      // Check for userId in URL for identity restoration
+      // Check for userId and ownerKey in URL for identity restoration
       const requestedUserId = url.searchParams.get("userId");
+      const requestedOwnerKey = url.searchParams.get("ownerKey");
 
       // Try to restore user identity from stored userId
       let user: User;
+      const isOwner =
+        !!requestedOwnerKey && this.validateOwnerKey(requestedOwnerKey);
 
       if (requestedUserId) {
         // Check if this userId is already connected (prevent duplicates)
@@ -163,14 +166,14 @@ export class RoomDO {
             user = {
               id: requestedUserId,
               name: restoredName,
-              isOwner: false,
+              isOwner,
             };
           } else {
             // User ID exists but no stored name - create new user with requested ID
             user = {
               id: requestedUserId,
               name: generateAnonymousName(),
-              isOwner: false,
+              isOwner,
             };
           }
         } else {
@@ -178,7 +181,7 @@ export class RoomDO {
           user = {
             id: generateId(16),
             name: generateAnonymousName(),
-            isOwner: false,
+            isOwner,
           };
         }
       } else {
@@ -186,7 +189,7 @@ export class RoomDO {
         user = {
           id: generateId(16),
           name: generateAnonymousName(),
-          isOwner: false,
+          isOwner,
         };
       }
 

--- a/worker/src/room.ts
+++ b/worker/src/room.ts
@@ -944,7 +944,7 @@ export class RoomDO {
     }
   }
 
-  async webSocketError(ws: WebSocket, error: unknown): Promise<void> {
+  async webSocketError(_ws: WebSocket, error: unknown): Promise<void> {
     console.error("WebSocket error:", error);
     // The close handler will be called after this
   }


### PR DESCRIPTION
**Summary**

  - Name persistence: Renamed user identity now persists across reconnections via server-side userNames map
  - Column scrollbar: Cards area scrolls properly when content overflows (fixed CSS flex-shrink on column header and draft area)
  - Card editing: Added inline editing for published cards (click-to-edit, Enter to save, Escape to cancel)
  - Owner badge in participants: ownerKey is now passed via WebSocket URL so the server can identify the room owner
  - Long text wrapping: Long unbroken words now wrap in the focus mode discussion modal